### PR TITLE
Add/react helmet

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "react": "16.13.1",
     "react-dom": "16.13.1",
+    "react-helmet": "^6.0.0",
     "styled-components": "5.1.0"
   },
   "devDependencies": {
@@ -30,8 +31,8 @@
     "@babel/preset-env": "7.9.5",
     "@babel/preset-react": "7.9.4",
     "babel-loader": "8.1.0",
-    "css-loader": "3.5.2",
     "copy-webpack-plugin": "5.1.1",
+    "css-loader": "3.5.2",
     "html-webpack-plugin": "4.2.0",
     "style-loader": "1.1.4",
     "webpack": "4.43.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
+import { Helmet } from 'react-helmet';
 
 import GlobalStyle from './styles/global';
 
@@ -8,9 +9,16 @@ class App extends Component {
   render () {
     return (
       <React.Fragment>
-      <GlobalStyle />
+        <GlobalStyle />
+
+        <Helmet>
+          <meta charSet="utf-8" />
+          <title>Modelo Reactjs Template</title>
+        </Helmet>
+
         <h1>hello world</h1>
-      </React.Fragment>
+
+    </React.Fragment>
     );
   }
 


### PR DESCRIPTION
Found it to be best practice to add elements to the `<head>` using [react-helmet](https://github.com/nfl/react-helmet), provides a cleaner and more adjustable code-base. Specifically when importing fonts in global styles component provided by [styled-components](styled-components.com/), we get an error:
```javascript
export const googlefonts = `
  // https://fonts.google.com/specimen/Work+Sans?selection.family=Work+Sans:400,500,600
  @import url('https://fonts.googleapis.com/css?family=Work+Sans:400,500,600&display=swap');
`
```
> Please do not use @ import CSS syntax in createGlobalStyle at this time, as the CSSOM APIs we use in production do not handle it well. Instead, we recommend using a library such as react-helmet to inject a typical <link> meta tag to the stylesheet, or simply embedding it manually in your index.html <head> section for a simpler app.

```html
  <Helmet>
    <meta charSet="utf-8" />
    <title>Modelo Reactjs Template</title>
    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Work+Sans:400,500,600&display=swap"> 
  </Helmet>
```
So instead we will use `<link>` tags to load in the font, with the help of react-helmet.
